### PR TITLE
call _recv_confirm after sending each file

### DIFF
--- a/scp.py
+++ b/scp.py
@@ -151,6 +151,7 @@ class SCPClient(object):
                     self._progress(basename, size, file_pos)
             chan.sendall('\x00')
             file_hdl.close()
+            self._recv_confirm()
 
     def _send_recursive(self, files):
         for base in files:


### PR DESCRIPTION
I noticed when I was transferring a 50MB tar.gz file that not all of the bytes were being sent (ls -l output on the remote host was different than the original). After debugging _send_files using pudb, simply setting a breakpoint and pausing the code execution allowed 'enough time' to pass that the transfer completed successfully. Looking at scp.c in openssh it seems they wait for some sort of response() after sending a file so I tried this with scp.py and it seems to be working from some limited testing.
