### PR TITLE
match every pushd with a popd in _send_recursive

### DIFF
--- a/scp.py
+++ b/scp.py
@@ -182,6 +182,9 @@ class SCPClient(object):
                 self._chdir(last_dir, root)
                 self._send_files([os.path.join(root, f) for f in fls])
                 last_dir = root
+            # back out of the directory
+            for i in range(len(os.path.split(last_dir))):
+                self._send_popd()
 
     def _send_pushd(self, directory):
         (mode, size, mtime, atime) = self._read_stats(directory)


### PR DESCRIPTION
Fixes a bug where files/directories may end up improperly nested on the
remote machine. For example on the client machine you run the following:

```
$ mkdir srcdir
$ mkdir srcdir/another
$ touch srcfile

scpclient.put(['srcdir', 'srcfile'], recursive=True)
```

Then on the remote machine the files end up like:

```
$ find $HOME
srcdir
srcdir/another
srcdir/another/srcfile
```

This patch fixes the issue by calling popd for each path component of
the last directory in the loop which changes the remote path back to
where we started before the last directory transfer.

See also jtriley/StarCluster#331
