### PR TITLE
fix deprecation warnings about e.message

### DIFF
--- a/scp.py
+++ b/scp.py
@@ -272,7 +272,7 @@ class SCPClient(object):
         try:
             file_hdl = file(path, 'wb')
         except IOError, e:
-            chan.send('\x01' + e.message)
+            chan.send('\x01' + str(e))
             chan.close()
             raise
 
@@ -331,7 +331,7 @@ class SCPClient(object):
             self._utime = None
             self._recv_dir = path
         except (OSError, SCPException), e:
-            self.channel.send('\x01' + e.message)
+            self.channel.send('\x01' + str(e))
             raise
 
     def _recv_popd(self, *cmd):


### PR DESCRIPTION
Using e.message is deprecated since 2.6. Changed e.message to e[0]
everywhere and also used str(e[0]) everywhere that the exception message
was being concatenated with a string.
