### PR TITLE
Fixes for fatal errors and python3

### DIFF
--- a/scp.py
+++ b/scp.py
@@ -244,9 +244,9 @@ class SCPClient(object):
             msg = self.channel.recv(512)
         except SocketTimeout:
             raise SCPException('Timout waiting for scp response')
-        if msg and msg[0] == b'\x00':
+        if msg and msg[0] == 0:
             return
-        elif msg and msg[0] == b'\x01':
+        elif msg and msg[0] == 1:
             raise SCPException(msg[1:])
         elif self.channel.recv_stderr_ready():
             msg = self.channel.recv_stderr(512)


### PR DESCRIPTION
Current master branch is unusable due to several issues. Hopefully this addresses them.

Note. (b'\x00')[0] is an integer, not another byte literal hence the update to the _recv_confirm logic. I've never been able to replicate the second case. Presumably it's something in the scp protocol?

``` python
elif msg and msg[0] == 1:
```
