### PR TITLE
Fixes _send_recursive with multiple files

### DIFF
--- a/scp.py
+++ b/scp.py
@@ -132,6 +132,7 @@ class SCPClient(object):
         """
         self.preserve_times = preserve_times
         self.channel = self.transport.open_session()
+        self._pushed = 0
         self.channel.settimeout(self.socket_timeout)
         scp_command = (b'scp -t ', b'scp -r -t ')[recursive]
         self.channel.exec_command(scp_command +
@@ -182,6 +183,7 @@ class SCPClient(object):
         rcsv = (b'', b' -r')[recursive]
         prsv = (b'', b' -p')[preserve_times]
         self.channel = self.transport.open_session()
+        self._pushed = 0
         self.channel.settimeout(self.socket_timeout)
         self.channel.exec_command(b"scp" +
                                   rcsv +
@@ -265,7 +267,7 @@ class SCPClient(object):
                 self._send_files([os.path.join(root, f) for f in fls])
                 last_dir = asbytes(root)
             # back out of the directory
-            for i in range(len(os.path.split(last_dir))):
+            while self._pushed > 0:
                 self._send_popd()
 
     def _send_pushd(self, directory):
@@ -276,10 +278,12 @@ class SCPClient(object):
         self.channel.sendall(('D%s 0 ' % mode).encode('ascii') +
                              basename.replace(b'\n', b'\\^J') + b'\n')
         self._recv_confirm()
+        self._pushed += 1
 
     def _send_popd(self):
         self.channel.sendall('E\n')
         self._recv_confirm()
+        self._pushed -= 1
 
     def _send_time(self, mtime, atime):
         self.channel.sendall(('T%d 0 %d 0\n' % (mtime, atime)).encode('ascii'))


### PR DESCRIPTION
In `_send_recursive()`, `os.path.split()` doesn't do what it looks like (it splits any path in 2 components). This calls `_send_popd()` an incorrect number of times, which will make the server drop the connection.

Right now, sending two directories with `scp.put(['dir1', 'dir2'], '/tmp/', True)` fails with `socket.error: Socket is closed`.

This probably needs more tests. ~~Version for my 'python3' branch is on -py3-recursive-popd`~~ (edit: rebased after #39 merge).
