### PR TITLE
Add session persistence

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,32 @@ Example
     scp.put('test.txt', 'test2.txt')
     scp.get('test2.txt')
 
+    scp.close()
+
+
+..  code-block::
+
+    $ md5sum test.txt test2.txt
+    fc264c65fb17b7db5237cf7ce1780769 test.txt
+    fc264c65fb17b7db5237cf7ce1780769 test2.txt
+
+Using 'with' keyword
+------------------
+
+..  code-block:: python
+
+    from paramiko import SSHClient
+    from scp import SCPClient
+
+    ssh = SSHClient()
+    ssh.load_system_host_keys()
+    ssh.connect('example.com')
+
+    with SCPClient(ssh.get_transport()) as scp:
+        scp.put('test.txt', 'test2.txt')
+        scp.get('test2.txt')
+
+
 ..  code-block::
 
     $ md5sum test.txt test2.txt

--- a/test.py
+++ b/test.py
@@ -107,9 +107,10 @@ class TestDownload(unittest.TestCase):
         os.mkdir(temp_in)
         os.chdir(temp_in)
         try:
-            scp = SCPClient(self.ssh.get_transport())
-            scp.get(filename, destination if destination is not None else u'.',
-                    preserve_times=True, recursive=recursive)
+            with SCPClient(self.ssh.get_transport()) as scp:
+                scp.get(filename,
+                        destination if destination is not None else u'.',
+                        preserve_times=True, recursive=recursive)
             actual = []
             def listdir(path, fpath):
                 for name in os.listdir(fpath):
@@ -204,8 +205,8 @@ class TestUpload(unittest.TestCase):
         previous = os.getcwd()
         try:
             os.chdir(self._temp)
-            scp = SCPClient(self.ssh.get_transport())
-            scp.put(filenames, destination, recursive)
+            with SCPClient(self.ssh.get_transport()) as scp:
+                scp.put(filenames, destination, recursive)
 
             chan = self.ssh.get_transport().open_session()
             chan.exec_command(


### PR DESCRIPTION
Besides improving performances, this change will make it possible to
use scp as a "drop-in" replacement to paramiko sftp.