### PR TITLE
Avoid exception chaining on non-existent file

### DIFF
--- a/scp.py
+++ b/scp.py
@@ -342,10 +342,9 @@ class SCPClient(object):
             assert msg[-1:] == b'\n'
             msg = msg[:-1]
             code = msg[0:1]
-            try:
-                command[code](msg[1:])
-            except KeyError:
+            if code not in command:
                 raise SCPException(asunicode(msg[1:]))
+            command[code](msg[1:])
         # directory times can't be set until we're done writing files
         self._set_dirtimes()
 


### PR DESCRIPTION
SCPException is raised from an except: block. On Python 3, this chains it with the previous KeyError. This small change prevents this.

Fixes #60
