### PR TITLE
Add putfo method to SCPClient #91

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,3 +55,33 @@ Using 'with' keyword
     $ md5sum test.txt test2.txt
     fc264c65fb17b7db5237cf7ce1780769 test.txt
     fc264c65fb17b7db5237cf7ce1780769 test2.txt
+
+
+Uploading file-like objects
+---------------------------
+
+The ``putfo`` method can be used to upload file-like objects:
+
+..  code-block:: python
+
+    import io
+    from paramiko import SSHClient
+    from scp import SCPClient
+
+    ssh = SSHClient()
+    ssh.load_system_host_keys()
+    ssh.connect('example.com')
+
+    # SCPCLient takes a paramiko transport as its only argument
+    scp = SCPClient(ssh.get_transport())
+
+    # generate in-memory file-like object
+    fl = io.BytesIO()
+    fl.write(b'test')
+    fl.seek(0)
+    # upload it directly from memory
+    scp.putfo(fl, '/tmp/test.txt')
+    # close connection
+    scp.close()
+    # close file handler
+    fl.close()


### PR DESCRIPTION
This method allows uploading file-like objects, eg:

- previously opened files
- in-memory files (`io.BytesIO` instances)

I had some troubles understanding the code in the test suite, I tried to do my best to add a meaningful test for the new method.

I look forward to receive feedback that will help me to improve the pull request.

References #70 and #91.