### PR TITLE
Make README.rst valid to accept by PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Example
     fc264c65fb17b7db5237cf7ce1780769 test2.txt
 
 Using 'with' keyword
-------------------
+--------------------
 
 ..  code-block:: python
 


### PR DESCRIPTION
* We need to make **README.rst** valid which could be accepted by [PyPI](https://pypi.org/project/scp/) as **long description** and display it in nice format.
* I used  [Readme Renderer](https://github.com/pypa/readme_renderer) tool to validate README.rst file. 
