### PR TITLE
added host ip and port to progress callback method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,11 @@ example below we print the percentage complete of the file transfer.
     ssh.connect('example.com')
 
     # Define progress callback that prints the current percentage completed for the file
-    # It prints IP address and ssh port, also.
+    def progress(filename, size, sent):
+        sys.stdout.write("%s\'s progress: %.2f%%   \r" % (filename, float(sent)/float(size)*100) )
+
+    # you can also add 4th parameter to track IP and port
+    # useful with multiple threads to track source
     def progress(filename, size, sent, peername):
         sys.stdout.write("(%s:%s) %s\'s progress: %.2f%%   \r" % (peername[0], peername[1], filename, float(sent)/float(size)*100) )
 

--- a/README.rst
+++ b/README.rst
@@ -109,8 +109,9 @@ example below we print the percentage complete of the file transfer.
     ssh.connect('example.com')
 
     # Define progress callback that prints the current percentage completed for the file
-    def progress(filename, size, sent):
-        sys.stdout.write("%s\'s progress: %.2f%%   \r" % (filename, float(sent)/float(size)*100) )
+    # It prints IP address and ssh port, also.
+    def progress(filename, size, sent, peername):
+        sys.stdout.write("(%s:%s) %s\'s progress: %.2f%%   \r" % (peername[0], peername[1], filename, float(sent)/float(size)*100) )
 
     # SCPCLient takes a paramiko transport and progress callback as its arguments.
     scp = SCPClient(ssh.get_transport(), progress = progress)

--- a/scp.py
+++ b/scp.py
@@ -120,7 +120,7 @@ class SCPClient(object):
     def __exit__(self, type, value, traceback):
         self.close()
 
-    def _progress_tracker(self, method, basename, size, file_pos, peername=""):
+    def _progress_tracker(self, method, basename, size, file_pos, peername):
         #count number of arguments
         count = method.__code__.co_argcount
         if count == 3:

--- a/scp.py
+++ b/scp.py
@@ -94,11 +94,11 @@ class SCPClient(object):
         @type buff_size: int
         @param socket_timeout: channel socket timeout in seconds
         @type socket_timeout: float
-        @param progress: callback - called with (filename, size, sent) during
-            transfers
+        @param progress: callback - called with (filename, size, sent, peername) during
+            transfers. peername is a tuple contains (IP, PORT)
         @param sanitize: function - called with filename, should return
             safe or escaped string.  Uses _sh_quote by default.
-        @type progress: function(string, int, int)
+        @type progress: function(string, int, int, tuple)
         """
         self.transport = transport
         self.buff_size = buff_size
@@ -111,6 +111,7 @@ class SCPClient(object):
         self._utime = None
         self.sanitize = sanitize
         self._dirtimes = {}
+        self.peername = self.transport.getpeername()
 
     def __enter__(self):
         self.channel = self._open()
@@ -262,16 +263,16 @@ class SCPClient(object):
         if self._progress:
             if size == 0:
                 # avoid divide-by-zero
-                self._progress(basename, 1, 1)
+                self._progress(basename, 1, 1, self.peername)
             else:
-                self._progress(basename, size, 0)
+                self._progress(basename, size, 0, self.peername)
         buff_size = self.buff_size
         chan = self.channel
         while file_pos < size:
             chan.sendall(fl.read(buff_size))
             file_pos = fl.tell()
             if self._progress:
-                self._progress(basename, size, file_pos)
+                self._progress(basename, size, file_pos, self.peername)
         chan.sendall('\x00')
         self._recv_confirm()
 
@@ -411,9 +412,9 @@ class SCPClient(object):
         if self._progress:
             if size == 0:
                 # avoid divide-by-zero
-                self._progress(path, 1, 1)
+                self._progress(path, 1, 1, self.peername)
             else:
-                self._progress(path, size, 0)
+                self._progress(path, size, 0, self.peername)
         buff_size = self.buff_size
         pos = 0
         chan.send(b'\x00')
@@ -425,7 +426,7 @@ class SCPClient(object):
                 file_hdl.write(chan.recv(buff_size))
                 pos = file_hdl.tell()
                 if self._progress:
-                    self._progress(path, size, pos)
+                    self._progress(path, size, pos, self.peername)
 
             msg = chan.recv(512)
             if msg and msg[0:1] != b'\x00':

--- a/scp.py
+++ b/scp.py
@@ -120,6 +120,17 @@ class SCPClient(object):
     def __exit__(self, type, value, traceback):
         self.close()
 
+    def _progress_tracker(self, method, basename, size, file_pos, peername=""):
+        #count number of arguments
+        count = method.__code__.co_argcount
+        if count == 3:
+            method(basename, size, file_pos)
+        elif count == 4:
+            method(basename, size, file_pos, peername)
+        else:
+            #do not break, just skip
+            pass
+
     def put(self, files, remote_path=b'.',
             recursive=False, preserve_times=False):
         """
@@ -263,16 +274,16 @@ class SCPClient(object):
         if self._progress:
             if size == 0:
                 # avoid divide-by-zero
-                self._progress(basename, 1, 1, self.peername)
+                self._progress_tracker(self._progress, basename, 1, 1, self.peername)
             else:
-                self._progress(basename, size, 0, self.peername)
+                self._progress_tracker(self._progress, basename, size, 0, self.peername)
         buff_size = self.buff_size
         chan = self.channel
         while file_pos < size:
             chan.sendall(fl.read(buff_size))
             file_pos = fl.tell()
             if self._progress:
-                self._progress(basename, size, file_pos, self.peername)
+                self._progress_tracker(self._progress, basename, size, file_pos, self.peername)
         chan.sendall('\x00')
         self._recv_confirm()
 
@@ -412,9 +423,9 @@ class SCPClient(object):
         if self._progress:
             if size == 0:
                 # avoid divide-by-zero
-                self._progress(path, 1, 1, self.peername)
+                self._progress_tracker(self._progress, path, 1, 1, self.peername)
             else:
-                self._progress(path, size, 0, self.peername)
+                self._progress_tracker(self._progress, path, size, 0, self.peername)
         buff_size = self.buff_size
         pos = 0
         chan.send(b'\x00')
@@ -426,8 +437,7 @@ class SCPClient(object):
                 file_hdl.write(chan.recv(buff_size))
                 pos = file_hdl.tell()
                 if self._progress:
-                    self._progress(path, size, pos, self.peername)
-
+                    self._progress_tracker(self._progress, path, size, pos, self.peername)
             msg = chan.recv(512)
             if msg and msg[0:1] != b'\x00':
                 raise SCPException(asunicode(msg[1:]))


### PR DESCRIPTION
Hi, 

I've been working with your awesome library to help me create multithreaded ssh/scp tool using _multiprocessing_ package. 

I've introduced a new variable _self.peername_ (_self.transport.getpeername()_ - _paramiko_ method), to be able to track IP and port of connected host.

One can now get origin of output that has been send back. Without this it's impossible to find out which thread progress refers to.
