### PR TITLE
Rewrite #114, use `progress4` name for new param

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,13 +112,14 @@ example below we print the percentage complete of the file transfer.
     def progress(filename, size, sent):
         sys.stdout.write("%s\'s progress: %.2f%%   \r" % (filename, float(sent)/float(size)*100) )
 
-    # you can also add 4th parameter to track IP and port
-    # useful with multiple threads to track source
-    def progress(filename, size, sent, peername):
-        sys.stdout.write("(%s:%s) %s\'s progress: %.2f%%   \r" % (peername[0], peername[1], filename, float(sent)/float(size)*100) )
-
     # SCPCLient takes a paramiko transport and progress callback as its arguments.
-    scp = SCPClient(ssh.get_transport(), progress = progress)
+    scp = SCPClient(ssh.get_transport(), progress=progress)
+
+    # you can also use progress4, which adds a 4th parameter to track IP and port
+    # useful with multiple threads to track source
+    def progress4(filename, size, sent, peername):
+        sys.stdout.write("(%s:%s) %s\'s progress: %.2f%%   \r" % (peername[0], peername[1], filename, float(sent)/float(size)*100) )
+    scp = SCPClient(ssh.get_transport(), progress4=progress4)
 
     scp.put('test.txt', '~/test.txt')
     # Should now be printing the current progress of your put function.

--- a/test.py
+++ b/test.py
@@ -209,7 +209,7 @@ class TestUpload(unittest.TestCase):
         cb4 = lambda filename, size, sent, peername: None
         try:
             os.chdir(self._temp)
-            with SCPClient(self.ssh.get_transport(), progress=cb4) as scp:
+            with SCPClient(self.ssh.get_transport(), progress4=cb4) as scp:
                 if not fl:
                     scp.put(filenames, destination, recursive)
                 else:
@@ -312,65 +312,6 @@ class TestUpAndDown(unittest.TestCase):
             assert open(testfile_rcvd).read() == 'TESTING\n'
         finally:
             os.chdir(previous)
-
-
-class TestProgressCallback(unittest.TestCase):
-    def setUp(self):
-        self.peer = ('localhost', 42345)
-        class T(object):
-            def getpeername(s):
-                return self.peer
-        self.scp = SCPClient(T())
-
-    def call_progress(self, progress):
-        self.scp._progress_tracker(progress, 'name', 100, 42, self.peer)
-
-    def test_functions(self):
-        called = [0]
-
-        def progress(name, size, pos):
-            called[0] += 1
-        self.call_progress(progress)
-        self.assertEqual(called, [1])
-
-        def progress(name, size, pos, peername):
-            called[0] += 1
-        self.call_progress(progress)
-        self.assertEqual(called, [2])
-
-    def test_methods(self):
-        called = [0]
-
-        class C(object):
-            def method3(self, name, size, pos):
-                called[0] += 1
-            def method4(self, name, size, pos, peername):
-                called[0] += 1
-            @classmethod
-            def c_method3(cls, name, size, pos):
-                called[0] += 1
-            @classmethod
-            def c_method4(cls, name, size, pos, peername):
-                called[0] += 1
-            @staticmethod
-            def s_method3(name, size, pos):
-                called[0] += 1
-            @staticmethod
-            def s_method4(name, size, pos, peername):
-                called[0] += 1
-
-        self.call_progress(C().method3)
-        self.assertEqual(called, [1])
-        self.call_progress(C().method4)
-        self.assertEqual(called, [2])
-        self.call_progress(C().c_method3)
-        self.assertEqual(called, [3])
-        self.call_progress(C().c_method4)
-        self.assertEqual(called, [4])
-        self.call_progress(C().s_method3)
-        self.assertEqual(called, [5])
-        self.call_progress(C().s_method4)
-        self.assertEqual(called, [6])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This reverts the behavior accepted by #114, and gets rid of the buggy introspection code.

To use the behavior requested by @grzegorzcode, just use the `progress4` parameter.

Fixes #117 #120 #121