### PR TITLE
Handle last POPD if _rename was set

### DIFF
--- a/scp.py
+++ b/scp.py
@@ -501,9 +501,9 @@ class SCPClient(object):
             raise
 
     def _recv_popd(self, *cmd):
-        assert self._depth > 0
-        self._depth -= 1
-        self._recv_dir = os.path.split(self._recv_dir)[0]
+        if self._depth > 0:
+            self._depth -= 1
+            self._recv_dir = os.path.split(self._recv_dir)[0]
 
     def _set_dirtimes(self):
         try:

--- a/test.py
+++ b/test.py
@@ -159,6 +159,11 @@ class TestDownload(unittest.TestCase):
                             u'bien rang\xE9\\b\xE8te'],
                            [b'bien rang\xC3\xA9', b'bien rang\xC3\xA9/file',
                             b'bien rang\xC3\xA9/b\xC3\xA8te'])
+        self.download_test(b'/tmp/bien rang\xC3\xA9', True, b'target',
+                           [u'target', u'target\\file',
+                            u'target\\b\xE8te'],
+                           [b'target', b'target/file',
+                            b'target/b\xC3\xA8te'])
 
     def test_get_invalid_unicode(self):
         self.download_test(b'/tmp/p\xE9t\xE9', False, u'target',


### PR DESCRIPTION
Fixes #129
This is a consequence of #127, there was a missing test.

If `_rename` was set and transferring a directory, the server might send a last POPD that will bring you above the destination. The server shouldn't write there, but no `AssertionError` should be triggered.

This patch ignores the POPD commands when `_depth == 0`. This means if bogus/malicious server writes to `dir/b` when `get(remote_path, "dir/a")` was called, it will write to `dir/a/b` instead (no exception will be raised).

This might fail if the server POPD out of the directory and PUSHD back into it (but why would it do that?)

Thanks @alanbchristie for the feedback.