### PR TITLE
make scp_command modifiable

### DIFF
--- a/scp.py
+++ b/scp.py
@@ -17,8 +17,8 @@ import types
 # this is quote from the shlex module, added in py3.3
 _find_unsafe = re.compile(br'[^\w@%+=:,./~-]').search
 
-
 SCP_COMMAND = b'scp '
+
 
 def _sh_quote(s):
     """Return a shell-escaped version of the string `s`."""

--- a/scp.py
+++ b/scp.py
@@ -18,6 +18,8 @@ import types
 _find_unsafe = re.compile(br'[^\w@%+=:,./~-]').search
 
 
+SCP_COMMAND = b'scp '
+
 def _sh_quote(s):
     """Return a shell-escaped version of the string `s`."""
     if not s:
@@ -123,6 +125,7 @@ class SCPClient(object):
         self.sanitize = sanitize
         self._dirtimes = {}
         self.peername = self.transport.getpeername()
+        self.scp_command = SCP_COMMAND
 
     def __enter__(self):
         self.channel = self._open()
@@ -152,7 +155,7 @@ class SCPClient(object):
         self.channel = self._open()
         self._pushed = 0
         self.channel.settimeout(self.socket_timeout)
-        scp_command = (b'scp -t ', b'scp -r -t ')[recursive]
+        scp_command = self.scp_command + (b'-t ', b'-r -t ')[recursive]
         self.channel.exec_command(scp_command +
                                   self.sanitize(asbytes(remote_path)))
         self._recv_confirm()
@@ -188,7 +191,7 @@ class SCPClient(object):
 
         self.channel = self._open()
         self.channel.settimeout(self.socket_timeout)
-        self.channel.exec_command(b'scp -t ' +
+        self.channel.exec_command(self.scp_command + b'-t ' +
                                   self.sanitize(asbytes(remote_path)))
         self._recv_confirm()
         self._send_file(fl, remote_path, mode, size=size)
@@ -230,7 +233,7 @@ class SCPClient(object):
         self.channel = self._open()
         self._pushed = 0
         self.channel.settimeout(self.socket_timeout)
-        self.channel.exec_command(b"scp" +
+        self.channel.exec_command(self.scp_command +
                                   rcsv +
                                   prsv +
                                   b" -f " +


### PR DESCRIPTION
We sometimes need to put files into root perm directories, like `/etc`. Currently this requires putting the file to a temporary directory then moving the file. This PR allows for the `scp_command` to be modified so that you can run for example `sudo scp`, which provided the user has disabled sudo password prompt, allows for scping straight to a root perm directory.

I've left this as a hidden feature, that requires setting `self.scp_command` to work.