### PR TITLE
Remove extra space in SSH command sent on get()

### DIFF
--- a/scp.py
+++ b/scp.py
@@ -233,7 +233,7 @@ class SCPClient(object):
         self.channel = self._open()
         self._pushed = 0
         self.channel.settimeout(self.socket_timeout)
-        self.channel.exec_command(self.scp_command + b' ' +
+        self.channel.exec_command(self.scp_command +
                                   rcsv +
                                   prsv +
                                   b" -f " +


### PR DESCRIPTION
Fixes #158