### PR TITLE
Use list constructor to coerce non-list files

### DIFF
--- a/scp.py
+++ b/scp.py
@@ -160,8 +160,8 @@ class SCPClient(object):
                                   self.sanitize(asbytes(remote_path)))
         self._recv_confirm()
 
-        if not isinstance(files, (list, tuple)):
-            files = list(files)
+        if not isinstance(files, (list, tuple, types.GeneratorType)):
+            files = [files]
 
         if recursive:
             self._send_recursive(files)

--- a/scp.py
+++ b/scp.py
@@ -161,7 +161,7 @@ class SCPClient(object):
         self._recv_confirm()
 
         if not isinstance(files, (list, tuple)):
-            files = [files]
+            files = list(files)
 
         if recursive:
             self._send_recursive(files)


### PR DESCRIPTION
If `files` is a generator, this will correctly produce a list of the
generator contents. Using a list literal just creates a singleton list
containing the generator object.