### PR TITLE
Accept non-list iterables in get() and put()

### DIFF
--- a/scp.py
+++ b/scp.py
@@ -49,6 +49,8 @@ def asbytes(s):
     """
     if isinstance(s, bytes):
         return s
+    elif pathlib and isinstance(s, pathlib.Path):
+        return bytes(s)
     else:
         return s.encode('utf-8')
 
@@ -332,6 +334,7 @@ class SCPClient(object):
 
     def _send_recursive(self, files):
         for base in files:
+            base = asbytes(base)
             if not os.path.isdir(base):
                 # filename mixed into the bunch
                 self._send_files([base])

--- a/scp.py
+++ b/scp.py
@@ -18,6 +18,15 @@ _find_unsafe = re.compile(br'[^\w@%+=:,./~-]').search
 
 SCP_COMMAND = b'scp'
 
+PATH_TYPES = (str, bytes)
+
+try:
+    import pathlib
+except ImportError:
+    pass
+else:
+    PATH_TYPES += pathlib.PurePath,
+
 
 def _sh_quote(s):
     """Return a shell-escaped version of the string `s`."""
@@ -159,8 +168,10 @@ class SCPClient(object):
                                   self.sanitize(asbytes(remote_path)))
         self._recv_confirm()
 
-        if not isinstance(files, (list, tuple)):
+        if isinstance(files, PATH_TYPES):
             files = [files]
+        else:
+            files = list(files)
 
         if recursive:
             self._send_recursive(files)
@@ -213,8 +224,10 @@ class SCPClient(object):
             and directories.
         @type preserve_times: bool
         """
-        if not isinstance(remote_path, (list, tuple)):
+        if isinstance(remote_path, PATH_TYPES):
             remote_path = [remote_path]
+        else:
+            remote_path = list(remote_path)
         remote_path = [self.sanitize(asbytes(r)) for r in remote_path]
         self._recv_dir = local_path or os.getcwd()
         self._depth = 0

--- a/test.py
+++ b/test.py
@@ -14,6 +14,10 @@ try:
     sys.modules['unittest'] = unittest
 except ImportError:
     import unittest
+try:
+    import pathlib
+except ImportError:
+    pathlib = None
 
 
 ssh_info = {
@@ -286,6 +290,13 @@ class TestUpload(unittest.TestCase):
                           b'dossi\xC3\xA9/bien rang\xC3\xA9',
                           b'dossi\xC3\xA9/bien rang\xC3\xA9/test',
                           b'r\xC3\xA9mi'])
+
+    @unittest.skipUnless(pathlib, "pathlib not available")
+    def test_pathlib(self):
+        self.upload_test(pathlib.Path(u'cl\xE9/dossi\xE9'), True,
+                         [b'dossi\xC3\xA9',
+                          b'dossi\xC3\xA9/bien rang\xC3\xA9',
+                          b'dossi\xC3\xA9/bien rang\xC3\xA9/test'])
 
     def test_putfo(self):
         fl = BytesIO()

--- a/test.py
+++ b/test.py
@@ -8,6 +8,7 @@ import shutil
 import sys
 from scp import SCPClient, SCPException, put, get
 import tempfile
+import types
 try:
     import unittest2 as unittest
     sys.modules['unittest'] = unittest
@@ -270,6 +271,12 @@ class TestUpload(unittest.TestCase):
                           b'dossi\xC3\xA9/bien rang\xC3\xA9/test'])
         self.upload_test([u'cl\xE9/dossi\xE9/bien rang\xE9',
                           u'cl\xE9/r\xE9mi'], True,
+                         [b'bien rang\xC3\xA9',
+                          b'bien rang\xC3\xA9/test',
+                          b'r\xC3\xA9mi'])
+        g = (n for n in (u'cl\xE9/dossi\xE9/bien rang\xE9', u'cl\xE9/r\xE9mi'))
+        assert isinstance(g, types.GeneratorType)
+        self.upload_test(g, True,
                          [b'bien rang\xC3\xA9',
                           b'bien rang\xC3\xA9/test',
                           b'r\xC3\xA9mi'])


### PR DESCRIPTION
Closes #163

Currently only `list` and `tuple` can be passed to `get()` and `put()`, anything else (like a generator or iterator) will be treated as a single path. This reverses the logic into a shortlist of path types, everything else is treated as an iterable and converted to a list.

Also fixes support for `pathlib` and test it.