### PR TITLE
Fix pathlib presence check

### DIFF
--- a/scp.py
+++ b/scp.py
@@ -23,7 +23,7 @@ PATH_TYPES = (str, bytes)
 try:
     import pathlib
 except ImportError:
-    pass
+    pathlib = None
 else:
     PATH_TYPES += pathlib.PurePath,
 


### PR DESCRIPTION
Fixes an issue with the pathlib presence check at [scp.py#L52](https://github.com/jbardin/scp.py/blob/97a68af7d264ed2d76abc0032cfe7659c6482194/scp.py#L52).