### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Pure python scp module
 ======================
 
-The scp.py module uses a paramiko transport to send and recieve files via the
+The scp.py module uses a paramiko transport to send and receive files via the
 scp1 protocol. This is the protocol as referenced from the openssh scp program,
 and has only been tested with this implementation.
 

--- a/scp.py
+++ b/scp.py
@@ -402,7 +402,7 @@ class SCPClient(object):
             # wait for command as long as we're open
             self.channel.sendall('\x00')
             msg = self.channel.recv(1024)
-            if not msg:  # chan closed while recving
+            if not msg:  # chan closed while receiving
                 break
             assert msg[-1:] == b'\n'
             msg = msg[:-1]


### PR DESCRIPTION
There are small typos in:
- README.rst
- scp.py

Fixes:
- Should read `receiving` rather than `recving`.
- Should read `receive` rather than `recieve`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md