### PR TITLE
change handeling of pathlib import

### DIFF
--- a/scp.py
+++ b/scp.py
@@ -36,8 +36,11 @@ try:
     if TYPE_CHECKING:
         import paramiko.transport
 
-    # unconditionally adding pathlib here because typing only works in python3 anyways and it's in stdlib
-    PathTypes = Union[str, bytes, "pathlib.PurePath"]
+    # this is some magic to make sure pyright doesn't get too confused with pathlib potentially being a nullable variable
+    import pathlib
+    PurePath = pathlib.PurePath
+
+    PathTypes = Union[str, bytes, PurePath]
 except ImportError:
     pass
 


### PR DESCRIPTION
Another tiny fix for type checkers. Pyright (the default type checker in VSCode) gets very confused with how the import was before. This change fixes that, so it works for mypy and pyright now.