### PR TITLE
Wait for remote scp process to exit before closing channel

### DIFF
--- a/scp.py
+++ b/scp.py
@@ -296,6 +296,11 @@ class SCPClient(object):
     def close(self):
         """close scp channel"""
         if self.channel is not None:
+            try:
+                self.channel.shutdown_write()
+                self.channel.recv_exit_status()
+            except (EOFError, OSError, paramiko.SSHException):
+                pass
             self.channel.close()
             self.channel = None
 


### PR DESCRIPTION
SCPClient.close() currently sends CHANNEL_CLOSE without first sending CHANNEL_EOF or waiting for the server's exit-status. The remote scp process may still be running (and on slow storage, still flushing) when the channel is torn down. On embedded sshds (e.g. Dropbear on slow storage) this leaves the channel in mid-teardown long enough that a subsequent exec_command on the same transport gets killed with "SSHException: Channel closed". The OpenSSH scp(1) client itself waits for the remote process to exit. This patch matches that behaviour.

Refs: #196